### PR TITLE
#63 feat: 마이페이지 라우팅, 페이퍼 목록을 위한 스크롤 추가

### DIFF
--- a/src/pages/MyPage/MyPageItem/index.tsx
+++ b/src/pages/MyPage/MyPageItem/index.tsx
@@ -17,6 +17,7 @@ const MyPageItem = ({ paper }: Props) => {
   const [isDropdown, setIsDropdown] = useState(false)
   const [isVisible, setIsVisible] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
+
   const handleClickDropdownList = () => {
     setIsDropdown(!isDropdown)
   }
@@ -42,10 +43,7 @@ const MyPageItem = ({ paper }: Props) => {
       <div className={styles.roll}>
         <div className={styles.paperInfoWrap}>
           <p>{paper.paperTitle}</p>
-          <button type="button" onClick={handleClickVisible}>
-            {isVisible ? <EyeIcon /> : <EyeOffIcon />}
-            {/* <LockIcon  /> */}
-          </button>
+          {isVisible ? <EyeIcon /> : <EyeOffIcon />}
         </div>
         <div className={styles.openDateWrap}>
           <p>{paper.dueDate}</p>
@@ -54,7 +52,12 @@ const MyPageItem = ({ paper }: Props) => {
           </button>
         </div>
       </div>
-        <MyPageDropDown paper={paper} isVisible={isVisible} isDropdown={isDropdown} handleClickVisible={handleClickVisible} />
+      <MyPageDropDown
+        paper={paper}
+        isVisible={isVisible}
+        isDropdown={isDropdown}
+        handleClickVisible={handleClickVisible}
+      />
     </div>
   )
 }

--- a/src/pages/MyPage/MyPageItem/index.tsx
+++ b/src/pages/MyPage/MyPageItem/index.tsx
@@ -8,7 +8,7 @@ import styles from './myPageItem.module.scss'
 import { useState, useRef, useEffect, BaseSyntheticEvent } from 'react'
 import MyPageDropDown from './MyPageDropdown'
 import PaperType from '@/utils/rollingPaper/Paper.type'
-
+import { useNavigate } from 'react-router-dom'
 interface Props {
   paper: PaperType
 }
@@ -17,6 +17,7 @@ const MyPageItem = ({ paper }: Props) => {
   const [isDropdown, setIsDropdown] = useState(false)
   const [isVisible, setIsVisible] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const navigate = useNavigate()
 
   const handleClickDropdownList = () => {
     setIsDropdown(!isDropdown)
@@ -24,6 +25,10 @@ const MyPageItem = ({ paper }: Props) => {
 
   const handleClickVisible = () => {
     setIsVisible(!isVisible)
+  }
+
+  const handleClickMoveToPaperDetail = () => {
+    navigate(`/rollingpaper/${paper.paperUrl}`)
   }
 
   useEffect(() => {
@@ -41,14 +46,18 @@ const MyPageItem = ({ paper }: Props) => {
   return (
     <div className={styles.myPageMainContent} ref={dropdownRef}>
       <div className={styles.roll}>
-        <div className={styles.paperInfoWrap}>
+        <button
+          type="button"
+          className={styles.paperInfoWrap}
+          onClick={handleClickMoveToPaperDetail}
+        >
           <p>{paper.paperTitle}</p>
           {isVisible ? <EyeIcon /> : <EyeOffIcon />}
-        </div>
+        </button>
         <div className={styles.openDateWrap}>
           <p>{paper.dueDate}</p>
           <button type="button" onClick={handleClickDropdownList}>
-            {isDropdown ? <ArrowDownIcon /> : <ArrowUpIcon />}
+            {isDropdown ? <ArrowUpIcon /> : <ArrowDownIcon />}
           </button>
         </div>
       </div>

--- a/src/pages/MyPage/MyPageItem/myPageItem.module.scss
+++ b/src/pages/MyPage/MyPageItem/myPageItem.module.scss
@@ -25,7 +25,11 @@
       border-bottom-left-radius: 28px;
 
       p {
-        word-break: keep-all;
+        width: 90%;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        word-break: break-all;
         color: colors.$white;
       }
 

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -43,7 +43,7 @@ const MyPage = () => {
       <div className={styles.myPageHeader}>
         <Header text="롤링페이퍼 저장소" type="only-title" />
       </div>
-      <section>
+      <section className={styles.myPageMain}>
         <div className={styles.myPageContentTitle}>
           <span>롤링 페이퍼 이름</span>
           <span>오픈 날짜</span>

--- a/src/pages/MyPage/myPage.module.scss
+++ b/src/pages/MyPage/myPage.module.scss
@@ -13,6 +13,8 @@
   }
 
   .myPageContentTitle {
+    position: sticky;
+    top: 0;
     display: flex;
     justify-content: space-around;
     align-items: center;
@@ -20,6 +22,18 @@
     border-top: 1.5px solid colors.$myPageBlack;
     border-bottom: 1.5px solid colors.$myPageBlack;
     font-size: 20px;
+    backdrop-filter: blur(4px);
+    z-index: 3;
+  }
+
+  .myPageMain {
+    height: 95%;
+    overflow-y: scroll;
+    scrollbar-width: none;
+  }
+
+  .myPageMain::-webkit-scrollbar {
+    display: none;
   }
 
   // Paper Add Button


### PR DESCRIPTION
### ISSUE
  - closes #63

### 작업
- 페이퍼 목록이 많아질 때 스크롤 추가
- 상세 페이지로 이동하기 위한 라우팅 추가
- 드롭다운의 svg 아이콘을 보다 의미에 맞도록 변경
- 롤링페이퍼 이름이 컨텐츠 크기를 넘어 줄바꿈이 되는 문제 처리

### 기타