### PR TITLE
#86 feat : 마이페이지 오픈일자에 따른 텍스트 하이라이트 효과 추가

### DIFF
--- a/src/pages/MyPage/MyPageItem/index.tsx
+++ b/src/pages/MyPage/MyPageItem/index.tsx
@@ -3,6 +3,7 @@ import { ReactComponent as ArrowUpIcon } from '@/assets/arrow-up.svg'
 import { useState, useRef, useEffect, BaseSyntheticEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import cx from 'classnames'
 import styles from './myPageItem.module.scss'
 import { convertTimeAndOffsetToDate } from '@/utils/rollingPaper/paper'
 
@@ -16,19 +17,22 @@ interface Props {
 const MyPageItem = ({ paper, changeOpenPaperState }: Props) => {
   const [isDropdown, setIsDropdown] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
-
+  const [isOpened, setIsOpened] = useState(false)
+  const openDateRef = useRef<HTMLParagraphElement>(null)
   const navigate = useNavigate()
   const handleClickDropdownList = () => {
     setIsDropdown(!isDropdown)
   }
 
-  const handleClickMoveToPaperDetail = () => {
-    const openDate = new Date(paper.dueDate).getTime() / 1000 / 60 / 60 / 24
+  const getDiffBetweenDate = (date: string): number => {
+    const openDate = new Date(date).getTime() / 1000 / 60 / 60 / 24
     const currentDate = convertTimeAndOffsetToDate()
-    const diff = currentDate - openDate
-    if (diff < 0) {
-      return changeOpenPaperState(true)
-    }
+    return currentDate - openDate
+  }
+
+  const handleClickMoveToPaperDetail = () => {
+    const diff = getDiffBetweenDate(paper.dueDate)
+    if (diff < 0) return changeOpenPaperState(true)
     navigate(`/rollingpaper/${paper.paperUrl}`)
   }
 
@@ -44,6 +48,13 @@ const MyPageItem = ({ paper, changeOpenPaperState }: Props) => {
     }
   }, [dropdownRef])
 
+  useEffect(() => {
+    const date = openDateRef.current?.textContent
+    if (!date) return
+    const diff = getDiffBetweenDate(date)
+    if (diff < 0) setIsOpened(true)
+  }, [isOpened])
+
   return (
     <div className={styles.myPageMainContent} ref={dropdownRef}>
       <div className={styles.roll}>
@@ -55,7 +66,9 @@ const MyPageItem = ({ paper, changeOpenPaperState }: Props) => {
           <p>{paper.paperTitle}</p>
         </button>
         <div className={styles.openDateWrap}>
-          <p>{paper.dueDate}</p>
+          <p className={cx(styles.dueDate, { [styles.isOpened]: isOpened })} ref={openDateRef}>
+            {paper.dueDate}
+          </p>
           <button type="button" onClick={handleClickDropdownList}>
             {isDropdown ? <ArrowUpIcon /> : <ArrowDownIcon />}
           </button>

--- a/src/pages/MyPage/MyPageItem/myPageItem.module.scss
+++ b/src/pages/MyPage/MyPageItem/myPageItem.module.scss
@@ -46,10 +46,14 @@
       border-top-right-radius: 28px;
       border-bottom-right-radius: 28px;
 
-      p {
+      .dueDate {
         padding-right: 12px;
         white-space: nowrap;
         color: colors.$myPageBlack;
+
+        &.isOpened {
+          color: colors.$textGray;
+        }
       }
     }
   }

--- a/src/pages/MyPage/myPage.module.scss
+++ b/src/pages/MyPage/myPage.module.scss
@@ -38,7 +38,7 @@
     }
 
     .paperList {
-      height: 95%;
+      height: 90%;
       margin-top: 10px;
       overflow-y: scroll;
       scrollbar-width: none;

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -14,6 +14,7 @@ $textGreen: #7dff00;
 $textPurple: #ad00ff;
 $textYellow: #ffd600;
 $textBlack: #212121;
+$textGray: #868686;
 
 // main color
 $mainBg: #fff8eb;
@@ -51,6 +52,7 @@ $colorMap: (
   'textPurple': $textPurple,
   'textYellow': $textYellow,
   'textBlack': $textBlack,
+  'textGray': $textGray,
   'mainBg': $mainBg,
   'point': $point,
   'subPoint': $subPoint,


### PR DESCRIPTION
### ISSUE
  - closes #86

### 작업
- 마이페이지 오픈일자에 따른 텍스트 하이라이트 효과 부여
- 마이페이지 내 롤링페이퍼 스크롤이 가능한 길이가 됐을 때, 가장 최 하단의 드롭다운이 잘리는 문제 해결

색상
- 컬러 코드 값 추가
  - $textGray : `#868686`

코드
- 텍스트 하이라이트 효과 기능을 구현하기 위해 새로 추가된 코드 (주요한 부분) `Mypage/MyPageItem/index.tsx`
```javascript
20  const [isOpened, setIsOpened] = useState(false)
21  const openDateRef = useRef<HTMLParagraphElement>(null)

51  useEffect(() => {
    const date = openDateRef.current?.textContent
    if (!date) return
    const diff = getDiffBetweenDate(date)
    if (diff < 0) setIsOpened(true)
56 }, [isOpened])
```

- 중복되는 코드 리팩토링 `Mypage/MyPageItem/index.tsx`
```javascript
27  const getDiffBetweenDate = (date: string): number => {
    const openDate = new Date(date).getTime() / 1000 / 60 / 60 / 24
    const currentDate = convertTimeAndOffsetToDate()
    return currentDate - openDate
31  }
```
- 함수를 아예 분리시키고 싶었지만 setState나 내부 함수가 의존되어 의도하던 대로 잘 이루어지지는 않았습니다.
- 대신에 현재 날짜와 기존 날짜를 계산하는 부분은 분리해서 중복을 제거했습니다.