### PR TITLE
#125 fix: 닉네임 모달, 헤더, 롤링페이퍼 수정

### DIFF
--- a/src/pages/Nickname/MakeNickname.tsx
+++ b/src/pages/Nickname/MakeNickname.tsx
@@ -1,6 +1,6 @@
 import { ChangeEventHandler, FormEvent, useState } from 'react'
+import styles from '@/components/Modal/modal.module.scss'
 
-import Modal from '@/components/Modal'
 import { ModalButton, ModalInput, ModalText } from '@/components/Modal/ModalItem'
 import { setNicknameAPI } from '@/api/user'
 import { EDIT_NAME, useName } from '@/store/nickname'
@@ -28,24 +28,26 @@ const MakeNickname = ({ setIsModalOpen }: Props) => {
   }
 
   return (
-    <Modal setIsModalOpen={setIsModalOpen}>
-      <form onSubmit={handleSubmitSave}>
-        <ModalText type="title">
-          내가 누구인지 알 수 있도록 <br />
-          닉네임을 설정해볼까요?
-        </ModalText>
-        <ModalText type="label">닉네임</ModalText>
-        <ModalInput
-          type="text"
-          name="nickname"
-          maxLength={8}
-          placeholder="8글자 이내로 나를 표현해봐요!"
-          onChange={handleNicknameChange}
-        />
-        {message && <ModalText type="warning">{message}</ModalText>}
-        <ModalButton type="submit">완료</ModalButton>
-      </form>
-    </Modal>
+    <div className={styles.modalContainer}>
+      <div className={styles.modalBody}>
+        <form onSubmit={handleSubmitSave}>
+          <ModalText type="title">
+            내가 누구인지 알 수 있도록 <br />
+            닉네임을 설정해볼까요?
+          </ModalText>
+          <ModalText type="label">닉네임</ModalText>
+          <ModalInput
+            type="text"
+            name="nickname"
+            maxLength={8}
+            placeholder="8글자 이내로 나를 표현해봐요!"
+            onChange={handleNicknameChange}
+          />
+          {message && <ModalText type="warning">{message}</ModalText>}
+          <ModalButton type="submit">완료</ModalButton>
+        </form>
+      </div>
+    </div>
   )
 }
 

--- a/src/pages/RollinPaper/RollingPaper.tsx
+++ b/src/pages/RollinPaper/RollingPaper.tsx
@@ -22,6 +22,8 @@ import StickerType from '@/utils/rollingPaper/Sticker.type'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import classNames from 'classnames'
+import { convertUrlToHostData } from '@/utils/rollingPaper/paper'
+import { LOAD_URL_NAME, useUrlName } from '@/store/urlNickname'
 
 const RollingPaper = () => {
   const urlId = useParams().rollingPaperId
@@ -40,6 +42,7 @@ const RollingPaper = () => {
   const [beforeOpen, setBeforeOpen] = useState(true)
   const [untilOpen, setUntilOpen] = useState('')
   const { state, dispatch } = useTheme()
+  const { dispatch: urlNameDispatch } = useUrlName()
 
   useEffect(() => {
     fetchPaperId_API(urlId, setRollingPaperId, navigate)
@@ -56,6 +59,20 @@ const RollingPaper = () => {
     }
     if (state.theme !== rollingPaper?.theme) dispatch({ type: 'toggle' })
   }, [rollingPaper])
+
+  const getPaperIdNickname = async () => {
+    if (!urlId) return
+    const hostData = await convertUrlToHostData(urlId)
+    if (!hostData) return
+    return urlNameDispatch({
+      type: LOAD_URL_NAME,
+      payload: hostData
+    })
+  }
+
+  useEffect(() => {
+    getPaperIdNickname()
+  }, [])
 
   const handleClickCard = useCallback(
     (id: number) => {


### PR DESCRIPTION
### ISSUE
  - closes #125

### 작업
- 최초 닉네임 설정시 모달 닫기 방지
- header nickname에서 rollingpaper 관여 부분 삭제
- 롤링페이퍼 hostname 업데이트 함수 추가

### 기타
- 얌얌 : src/pages/RollinPaper/RollingPaper.tsx 부분에 임시로 hostname refresh 부분 추가해두었습니다!
