### PR TITLE
#148 fix: 애드블록 방지 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "adblock-detect-react": "^1.1.0",
     "axios": "^0.27.2",
     "classnames": "^2.3.1",
     "ga-4-react": "^0.1.281",
@@ -34,6 +33,7 @@
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^2.0.0",
+    "adblock-detect-react": "^1.1.0",
     "typescript": "^4.6.4",
     "vite": "^3.0.0"
   }

--- a/src/hooks/useAdBlockDetect.tsx
+++ b/src/hooks/useAdBlockDetect.tsx
@@ -1,17 +1,32 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useDetectAdBlock } from 'adblock-detect-react'
+import axios from 'axios'
 
-import Ads from '@/pages/Ads'
+import KakaoFit from '@/pages/KakaoFit'
 
 export const useAdBlockDetect = () => {
+  const [isBlocked, setIsBlocked] = useState(false)
   const adBlockDetected = useDetectAdBlock()
 
+  useEffect(() => {
+    axios
+      .request({
+        url: `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js`
+      })
+      .then(() => {
+        setIsBlocked(false)
+      })
+      .catch(() => {
+        setIsBlocked(true)
+      })
+  }, [])
+
   const adComponent = useMemo(() => {
-    if (adBlockDetected) {
-      window.alert('ad block detected')
+    if (adBlockDetected || isBlocked) {
+      window.alert('애드블록을 해제하면 더 원활하게 롤링페이퍼를 사용할 수 있어요!')
       return ''
     }
-    return <Ads />
+    return <KakaoFit />
   }, [])
 
   return <div>{adComponent}</div>

--- a/src/pages/KakaoFit/index.tsx
+++ b/src/pages/KakaoFit/index.tsx
@@ -1,13 +1,7 @@
 import { memo, useEffect, useRef } from 'react'
 
-const Ads = () => {
+const KakaoFit = () => {
   const adRef = useRef<boolean>(false)
-
-  const adFunction = (ins: HTMLModElement, script: HTMLScriptElement) => {
-    document.querySelector('.aside__kakaoAdFit')?.appendChild(ins)
-    document.querySelector('.aside__kakaoAdFit')?.appendChild(script)
-    return null
-  }
 
   useEffect(() => {
     if (adRef.current) {
@@ -20,7 +14,7 @@ const Ads = () => {
       noAds.style.width = '100%'
       noAds.style.height = '50px'
       noAds.style.backgroundColor = '#DBDBDB'
-      document.querySelector('.aside__kakaoAdFit')?.appendChild(noAds)
+      document.querySelector('.aside__kakaoFit')?.appendChild(noAds)
       return
     }
 
@@ -37,16 +31,18 @@ const Ads = () => {
     script.async = true
     script.type = 'text/javascript'
     script.src = '//t1.daumcdn.net/kas/static/ba.min.js'
-    script.onload = adFunction(ins, script)
+
+    document.querySelector('.aside__kakaoFit')?.appendChild(ins)
+    document.querySelector('.aside__kakaoFit')?.appendChild(script)
 
     adRef.current = true
   }, [])
 
   return (
     <>
-      <aside className="aside__kakaoAdFit"></aside>
+      <aside className="aside__kakaoFit"></aside>
     </>
   )
 }
 
-export default memo(Ads)
+export default memo(KakaoFit)


### PR DESCRIPTION
### ISSUE
  - closes #148 

### 작업
- 애드블록 방지 수정

### 기타
- 모두가 알면 좋을 지식, 해결 과정

- `Q. `
  - 애드블록 확장 프로그램을 설치한 사용자가, 
  - 흰 화면으로 오류나면서 아예 롤링페이퍼 자체를 볼 수 없었던 이유

- `A. `
  - 애드블록의 광고 차단 원리 중 하나가 'ad'이름을 가진 것들을 차단하는 것으로 보아,
  - 컴포넌트 명을 Ads로 만들어서, 컴포넌트 자체가 방지된 것으로 추측합니다. 
  - KakaoFit 으로 컴포넌트 명을 변경하니 해당 오류는 수정되었습니다.
